### PR TITLE
Ignore: just trying to trigger jupyterlab_server CI to investigate a failure in another project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ git clone https://github.com/jupyterlab/jupyterlab_server.git
 cd jupyterlab_server
 pip install -e .
 ```
+
+test


### PR DESCRIPTION
It works well on Python 3.8+ but fails on older versions trying to blindly investigate which dependency causes this.

```python
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jsonschema/__init__.py", line 31, in <module>
    from importlib import metadata
ImportError: cannot import name 'metadata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/importlib_metadata/_compat.py", line 8, in <module>
    from typing import Protocol
ImportError: cannot import name 'Protocol'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jupyterlab_server/server.py", line 20, in <module>
    from notebook.notebookapp import aliases, flags, NotebookApp as ServerApp
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/notebook/notebookapp.py", line 85, in <module>
    from .services.contents.manager import ContentsManager
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/notebook/services/contents/manager.py", line 17, in <module>
    from nbformat import sign, validate as validate_nb, ValidationError
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/nbformat/__init__.py", line 32, in <module>
    from .validator import validate, ValidationError
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/nbformat/validator.py", line 12, in <module>
    from .json_compat import get_current_validator, ValidationError
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/nbformat/json_compat.py", line 10, in <module>
    import jsonschema
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jsonschema/__init__.py", line 33, in <module>
    import importlib_metadata as metadata
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 15, in <module>
    from ._compat import (
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/importlib_metadata/_compat.py", line 15, in <module>
    from typing_extensions import Protocol  # type: ignore
ModuleNotFoundError: No module named 'typing_extensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/miniconda/envs/jupyterlab-lsp/bin/jlpm", line 6, in <module>
    from jupyterlab.jlpmapp import main
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jupyterlab/jlpmapp.py", line 9, in <module>
    from jupyterlab_server.process import which, subprocess
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jupyterlab_server/__init__.py", line 4, in <module>
    from .app import LabServerApp
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jupyterlab_server/app.py", line 9, in <module>
    from .server import ServerApp
  File "/usr/share/miniconda/envs/jupyterlab-lsp/lib/python3.6/site-packages/jupyterlab_server/server.py", line 26, in <module>
    from jupyter_server.base.handlers import (                          # noqa
ModuleNotFoundError: No module named 'jupyter_server'

```